### PR TITLE
Fix FAB opacity jumping on Cupertino

### DIFF
--- a/lib/page/common/platform_fab.dart
+++ b/lib/page/common/platform_fab.dart
@@ -11,10 +11,12 @@ class PlatformFAB extends StatelessWidget {
   final VoidCallback onPressed;
   final Widget child;
   final Object? heroTag;
+  final double opacity;
   const PlatformFAB({
     super.key,
     required this.onPressed,
     required this.child,
+    this.opacity = 1,
     this.heroTag,
   });
   @override
@@ -23,12 +25,15 @@ class PlatformFAB extends StatelessWidget {
     return PlatformWidget(
       cupertino: (context, _) {
         const fabRadius = BorderRadius.all(Radius.circular(8));
+        // Reduce blur before opacity
+        final double sigma = 15 * Curves.easeIn.transform((opacity*1.5 - 0.5).clamp(0, 1));
+        final shadowColor = Colors.black.withOpacity(0.26*opacity);
         return Container(
-          decoration: const BoxDecoration(
+          decoration: BoxDecoration(
             borderRadius: fabRadius,
             boxShadow: [
               OutlineBoxShadow(
-                color: Colors.black26,
+                color: shadowColor,
                 blurRadius: 4,
               ),
             ],
@@ -36,27 +41,33 @@ class PlatformFAB extends StatelessWidget {
           child: ClipRRect(
             borderRadius: fabRadius,
             child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+              filter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
               child: SizedBox(
                 width: 50,
                 height: 50,
-                child: CupertinoButton(
-                    padding: EdgeInsets.zero,
-                    color: CupertinoDynamicColor.resolve(CupertinoColors.secondarySystemBackground, context).withAlpha(210),
-                    pressedOpacity: 0.9,
-                    onPressed: onPressed,
-                    child: child
+                child: Opacity(
+                  opacity: opacity,
+                  child: CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      color: CupertinoDynamicColor.resolve(CupertinoColors.secondarySystemBackground, context).withAlpha(210),
+                      pressedOpacity: 0.9,
+                      onPressed: onPressed,
+                      child: child
+                  ),
                 ),
               ),
             ),
           ),
         );
       },
-      material: (_, __) => FloatingActionButton(
-        heroTag: heroTag,
-        backgroundColor: theme.colorScheme.surface,
-        onPressed: onPressed,
-        child: child,
+      material: (_, __) => Opacity(
+        opacity: opacity,
+        child: FloatingActionButton(
+          heroTag: heroTag,
+          backgroundColor: theme.colorScheme.surface,
+          onPressed: onPressed,
+          child: child,
+        ),
       ),
     );
   }

--- a/lib/page/home_page.dart
+++ b/lib/page/home_page.dart
@@ -132,10 +132,12 @@ class _HomeScreenState extends State<HomeScreen> {
             child: Visibility(
               visible: !_panelController.isAttached ? true
                   : 1 > (_panelController.panelPosition - _panelController.snapPoint) / (0.2 * (1 - _panelController.snapPoint)),
-              child: Opacity(
+              child: MapFabs(
                 opacity: !_panelController.isAttached ? 1
-                    : 1 - clampDouble((_panelController.panelPosition - _panelController.snapPoint) / (0.2 * (1 - _panelController.snapPoint)), 0, 1),
-                child: MapFabs(),
+                    : Curves.easeInOut.transform(
+                    1 - clampDouble((_panelController.panelPosition - _panelController.snapPoint)
+                        / (0.2 * (1 - _panelController.snapPoint)), 0, 1)
+                ),
               ),
             ),
           ),

--- a/lib/page/home_page/map_fabs.dart
+++ b/lib/page/home_page/map_fabs.dart
@@ -11,8 +11,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// The floating action buttons used on the map page. Holds the location and add hazard [PlatformFAB].
 class MapFabs extends ConsumerWidget {
+  final double opacity;
 
-  const MapFabs({super.key});
+  const MapFabs({super.key, this.opacity = 1});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -26,6 +27,7 @@ class MapFabs extends ConsumerWidget {
             builder: (context, ref, child) {
               return PlatformFAB(
                 heroTag: "add_hazard_fab",
+                opacity: opacity,
                 onPressed: () async {
                   showCupertinoModalPopup(
                     context: context,
@@ -65,6 +67,7 @@ class MapFabs extends ConsumerWidget {
               final followOnLocationTarget = ref.watch(alignPositionTargetProvider);
               return PlatformFAB(
                 heroTag: "location_fab",
+                opacity: opacity,
                 onPressed: () async {
                   final status = await ref.read(locationPermissionStatusProvider.notifier).checkPermission();
                   if (!context.mounted) return;


### PR DESCRIPTION
Since PlatformFAB renders a BackdropFilter on cupertino, if it is wrapped in an opacity widget the backdrop filter can no longer read the backdrop. 

https://github.com/flutter/flutter/issues/31706

Moves opacity to a child of BackdropFilter.