### PR TITLE
Switch to bring your own uuid for hazard creation and updates, bundle…

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -6,8 +6,8 @@ import 'package:latlong2/latlong.dart';
 import 'package:uuid/uuid.dart';
 
 //const kApiUrl = "https://forestpark.elliotnash.org/api/v1";
-const kApiUrl = "https://forestpark.cecs.pdx.edu/staging/v1";
-// const kApiUrl = "http://192.168.0.247:8000";
+// const kApiUrl = "https://forestpark.cecs.pdx.edu/staging/v1";
+const kApiUrl = "http://192.168.0.247:8000";
 // const kApiUrl = "http://localhost:8000/";
 
 // This is for development only.

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -28,6 +28,9 @@ class HazardsTable extends Table {
   IntColumn get node => integer()();
   RealColumn get lat => real()();
   RealColumn get long => real()();
+  BoolColumn get offline => boolean()();
+  TextColumn get blurHash => text().nullable()();
+  TextColumn get image => text().nullable().unique()();
 
   @override
   Set<Column> get primaryKey => {uuid};
@@ -39,6 +42,7 @@ class HazardUpdatesTable extends Table {
   TextColumn get hazard => text().references(HazardsTable, #uuid)();
   DateTimeColumn get time => dateTime()();
   BoolColumn get active => boolean()();
+  BoolColumn get offline => boolean()();
   TextColumn get blurHash => text().nullable()();
   TextColumn get image => text().nullable().unique()();
 
@@ -61,6 +65,7 @@ class QueueTable extends Table {
   TextColumn get taskId => text()();
   TextColumn get requestType => textEnum<QueuedRequestType>()();
   TextColumn get filePath => text()();
+  TextColumn get associatedUuid => text()();
 
   @override
   Set<Column> get primaryKey => {taskId};

--- a/lib/model/hazard.dart
+++ b/lib/model/hazard.dart
@@ -18,10 +18,25 @@ class HazardModel with _$HazardModel implements drift.Insertable<HazardModel> {
     required DateTime time,
     required HazardType hazard,
     required SnappedLatLng location,
-    // TODO these probably can be removed.
+    required bool offline,
     String? blurHash,
     String? image,
   }) = _HazardModel;
+
+  factory HazardModel.create({
+    required HazardType hazard,
+    required SnappedLatLng location,
+    String? blurHash,
+    String? image,
+  }) => HazardModel(
+    uuid: kUuidGen.v1(),
+    time: DateTime.now(),
+    hazard: hazard,
+    location: location,
+    offline: true,
+    blurHash: blurHash,
+    image: image,
+  );
 
   /// Maps a database [HazardsTable] row to a [HazardModel].
   factory HazardModel.fromDb({
@@ -32,11 +47,17 @@ class HazardModel with _$HazardModel implements drift.Insertable<HazardModel> {
     required int node,
     required double lat,
     required double long,
+    required bool offline,
+    String? blurHash,
+    String? image,
   }) => HazardModel(
     uuid: uuid,
     time: time,
     hazard: hazard,
     location: SnappedLatLng(trail, node, LatLng(lat, long)),
+    offline: offline,
+    blurHash: blurHash,
+    image: image,
   );
 
   /// Maps a [HazardModel] to a database [HazardsTable] row.
@@ -50,24 +71,13 @@ class HazardModel with _$HazardModel implements drift.Insertable<HazardModel> {
         node: drift.Value(location.node),
         lat: drift.Value(location.latitude),
         long: drift.Value(location.longitude),
+        offline: drift.Value(offline),
+        blurHash: drift.Value(blurHash),
+        image: drift.Value(image),
       ).toColumns(nullToAbsent);
 
   factory HazardModel.fromJson(Map<String, dynamic> json) =>
       _$HazardModelFromJson(json);
 
   String timeString() => kDisplayDateFormat.format(time.toLocal());
-}
-
-@freezed
-class HazardRequestModel with _$HazardRequestModel {
-  const HazardRequestModel._();
-  const factory HazardRequestModel({
-    required HazardType hazard,
-    required SnappedLatLng location,
-    String? blurHash,
-    String? image,
-  }) = _HazardRequestModel;
-
-  factory HazardRequestModel.fromJson(Map<String, dynamic> json) =>
-      _$HazardRequestModelFromJson(json);
 }

--- a/lib/model/hazard_new_response.dart
+++ b/lib/model/hazard_new_response.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart';
+import 'package:forest_park_reports/model/hazard.dart';
+import 'package:forest_park_reports/model/hazard_update.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'hazard_new_response.g.dart';
+part 'hazard_new_response.freezed.dart';
+
+@freezed
+class HazardNewResponseModel with _$HazardNewResponseModel {
+  const HazardNewResponseModel._();
+  const factory HazardNewResponseModel({
+    required HazardModel hazard,
+    required HazardUpdateList updates,
+  }) = _HazardNewResponseModel;
+
+  factory HazardNewResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$HazardNewResponseModelFromJson(json);
+}

--- a/lib/model/hazard_update.dart
+++ b/lib/model/hazard_update.dart
@@ -26,6 +26,16 @@ class HazardUpdateList extends ListBase<HazardUpdateModel> {
 
   String? get lastImage => lastWhereOrNull((e) => e.image != null)?.image;
   String? get lastBlurHash => lastWhereOrNull((e) => e.blurHash != null)?.blurHash;
+
+  factory HazardUpdateList.fromJson(dynamic json) => HazardUpdateList([
+    for (final update in json)
+      HazardUpdateModel.fromJson(update),
+  ]);
+
+  List<Map<String, dynamic>> toJson() => [
+    for (final update in this)
+      update.toJson(),
+  ];
 }
 
 @freezed
@@ -36,9 +46,25 @@ class HazardUpdateModel with _$HazardUpdateModel implements drift.Insertable<Haz
     required String hazard,
     required DateTime time,
     required bool active,
+    @Default(false) bool offline,
     String? blurHash,
     String? image,
   }) = _HazardUpdateModel;
+
+  factory HazardUpdateModel.create({
+    required String hazard,
+    required bool active,
+    String? blurHash,
+    String? image,
+  }) => HazardUpdateModel(
+    uuid: kUuidGen.v1(),
+    hazard: hazard,
+    time: DateTime.now(),
+    active: active,
+    offline: true,
+    blurHash: blurHash,
+    image: image,
+  );
 
   /// Maps a [HazardUpdateModel] to a database [HazardUpdatesTable] row.
   @override
@@ -48,6 +74,7 @@ class HazardUpdateModel with _$HazardUpdateModel implements drift.Insertable<Haz
         hazard: drift.Value(hazard),
         time: drift.Value(time),
         active: drift.Value(active),
+        offline: drift.Value(offline),
         blurHash: drift.Value(blurHash),
         image: drift.Value(image),
       ).toColumns(nullToAbsent);
@@ -56,18 +83,4 @@ class HazardUpdateModel with _$HazardUpdateModel implements drift.Insertable<Haz
       _$HazardUpdateModelFromJson(json);
 
   String timeString() => kDisplayDateFormat.format(time.toLocal());
-}
-
-@freezed
-class HazardUpdateRequestModel with _$HazardUpdateRequestModel {
-  const HazardUpdateRequestModel._();
-  const factory HazardUpdateRequestModel({
-    required String hazard,
-    required bool active,
-    String? blurHash,
-    String? image,
-  }) = _HazardUpdateRequestModel;
-
-  factory HazardUpdateRequestModel.fromJson(Map<String, dynamic> json) =>
-      _$HazardUpdateRequestModelFromJson(json);
 }

--- a/lib/model/queued_request.dart
+++ b/lib/model/queued_request.dart
@@ -15,6 +15,7 @@ class QueuedRequestModel
     required String taskId,
     required QueuedRequestType requestType,
     required String filePath,
+    required String associatedUuid,
   }) = _QueuedRequestModel;
 
   /// Maps a [QueuedRequestModel] to a database [QueueTable] row.
@@ -24,6 +25,7 @@ class QueuedRequestModel
         taskId: drift.Value(taskId),
         requestType: drift.Value(requestType),
         filePath: drift.Value(filePath),
+        associatedUuid: drift.Value(associatedUuid)
       ).toColumns(nullToAbsent);
 
   factory QueuedRequestModel.fromJson(Map<String, dynamic> json) =>

--- a/lib/page/common/add_hazard_modal.dart
+++ b/lib/page/common/add_hazard_modal.dart
@@ -79,10 +79,11 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
 
     final activeHazardNotifier = ref.read(activeHazardProvider.notifier);
 
-    await activeHazardNotifier.createHazard(HazardRequestModel(
+    await activeHazardNotifier.createHazard(
       hazard: _selectedHazard!,
       location: snappedLoc.location,
-    ), imageFile: _image);
+      imageFile: _image
+    );
 
     showAlertBanner(
       child: const Text("Your report has been queued"),

--- a/lib/page/home_page/panel_page.dart
+++ b/lib/page/home_page/panel_page.dart
@@ -70,10 +70,8 @@ class PanelPage extends ConsumerWidget {
                     }
 
                     ref.read(activeHazardProvider.notifier).updateHazard(
-                      HazardUpdateRequestModel(
-                        hazard: selectedHazard.uuid,
-                        active: false,
-                      ),
+                      hazard: selectedHazard.uuid,
+                      active: false,
                     );
                     ref.read(panelPositionProvider.notifier).move(PanelState.HIDDEN);
                     ref.read(selectedHazardProvider.notifier).deselect();
@@ -106,10 +104,8 @@ class PanelPage extends ConsumerWidget {
                     }
 
                     ref.read(activeHazardProvider.notifier).updateHazard(
-                      HazardUpdateRequestModel(
-                        hazard: selectedHazard.uuid,
-                        active: true,
-                      ),
+                      hazard: selectedHazard.uuid,
+                      active: true,
                     );
                     ref.read(panelPositionProvider.notifier).move(PanelState.HIDDEN);
                     ref.read(selectedHazardProvider.notifier).deselect();

--- a/lib/provider/hazard_photo_provider.dart
+++ b/lib/provider/hazard_photo_provider.dart
@@ -21,15 +21,16 @@ class HazardPhoto extends _$HazardPhoto {
     if (kIsWeb) {
       data = await _fetch(uuid);
     } else {
+      final imageName = "$uuid.jpeg";
       // Read all cached image filenames and see if any match the uuid we need.
       final imageDir = (await ref.watch(directoryProvider(kImageDirectory).future))!;
-      final hasImage = await imageDir.list().any((f) => f.uri.pathSegments.last == uuid);
+      final hasImage = await imageDir.list().any((f) => f.uri.pathSegments.last == imageName);
       // If image doesn't exist in cache (or path exists but is not a File) fetch from server.
       if (!hasImage) {
         data = await _fetch(uuid);
       } else {
         // Otherwise load image from cache
-        final imageFile = File(join(imageDir.path, uuid));
+        final imageFile = File(join(imageDir.path, imageName));
         data = await imageFile.readAsBytes();
       }
     }
@@ -56,7 +57,7 @@ class HazardPhoto extends _$HazardPhoto {
   Future<void> _saveImage(String uuid, Uint8List data) async {
     // Get image path and ensure exists.
     final imageDir = (await ref.read(directoryProvider(kImageDirectory).future))!;
-    final imageFile = File(join(imageDir.path, uuid));
+    final imageFile = File(join(imageDir.path, "$uuid.jpeg"));
     await imageFile.create();
     // Write data.
     await imageFile.writeAsBytes(data);

--- a/lib/util/offline_uploader.dart
+++ b/lib/util/offline_uploader.dart
@@ -7,6 +7,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:forest_park_reports/consts.dart';
 import 'package:forest_park_reports/main.dart';
 import 'package:forest_park_reports/model/hazard.dart';
+import 'package:forest_park_reports/model/hazard_new_response.dart';
 import 'package:forest_park_reports/model/hazard_update.dart';
 import 'package:forest_park_reports/model/queued_request.dart';
 import 'package:forest_park_reports/provider/directory_provider.dart';
@@ -108,7 +109,7 @@ class OfflineUploader {
     switch(queuedRequestResponse.requestType) {
       case QueuedRequestType.newHazard:
         if (data != null) {
-          final hazard = HazardModel.fromJson(data);
+          final hazard = HazardNewResponseModel.fromJson(data);
           providerContainer.read(activeHazardProvider.notifier)
               .handleCreateResponse(hazard);
         }
@@ -134,6 +135,7 @@ class OfflineUploader {
     required String url,
     required Map<String, dynamic> data,
     required QueuedRequestType requestType,
+    required String associatedUuid,
     Map<String, String>? headers,
   }) async {
     // TODO use dio on web.
@@ -153,6 +155,7 @@ class OfflineUploader {
       url: url,
       filePath: file.path,
       requestType: requestType,
+      associatedUuid: associatedUuid,
       headers: headerMap,
     );
   }
@@ -165,6 +168,7 @@ class OfflineUploader {
     required String url,
     required String filePath,
     required QueuedRequestType requestType,
+    required String associatedUuid,
     bool multipart = false,
     Map<String, String>? headers,
   }) async {
@@ -195,7 +199,8 @@ class OfflineUploader {
       QueuedRequestModel(
         taskId: taskId,
         requestType: requestType,
-        filePath: filePath
+        filePath: filePath,
+        associatedUuid: associatedUuid,
       ),
     );
   }


### PR DESCRIPTION
Switches to bring your own uuid for hazard creation and updates. This allows storing local copies of hazard objects in client cache while offline.

Bundles hazard/new hazard and updates together to reduce the number of requests required - helps in low network environment

Closes https://github.com/trilliumlab/forest-park-reports-server/issues/4