### PR TITLE
Rework notifications / add hazard flow

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -19,8 +19,9 @@ const kPlatformOverride = null;
 // Allows a user to submit hazards and updates without appropriate proximity.
 const bool kLocationOverrideEnabled = true;
 
-// Tolerance in meters used when 
-const double kLocationTolerance = 25;
+// Tolerance in meters used when creating/updating a hazard
+const double kAddLocationTolerance = 25;
+const double kUpdateLocationTolerance = 50;
 
 // Example: 11:53 AM July 12 2022
 final DateFormat kDisplayDateFormat = DateFormat('hh:mm a MMMM dd y');

--- a/lib/model/hazard.dart
+++ b/lib/model/hazard.dart
@@ -26,10 +26,11 @@ class HazardModel with _$HazardModel implements drift.Insertable<HazardModel> {
   factory HazardModel.create({
     required HazardType hazard,
     required SnappedLatLng location,
+    String? uuid,
     String? blurHash,
     String? image,
   }) => HazardModel(
-    uuid: kUuidGen.v1(),
+    uuid: uuid ?? kUuidGen.v1(),
     time: DateTime.now(),
     hazard: hazard,
     location: location,

--- a/lib/model/hazard_update.dart
+++ b/lib/model/hazard_update.dart
@@ -54,10 +54,11 @@ class HazardUpdateModel with _$HazardUpdateModel implements drift.Insertable<Haz
   factory HazardUpdateModel.create({
     required String hazard,
     required bool active,
+    String? uuid,
     String? blurHash,
     String? image,
   }) => HazardUpdateModel(
-    uuid: kUuidGen.v1(),
+    uuid: uuid ?? kUuidGen.v1(),
     hazard: hazard,
     time: DateTime.now(),
     active: active,

--- a/lib/page/common/add_hazard_modal.dart
+++ b/lib/page/common/add_hazard_modal.dart
@@ -29,6 +29,7 @@ class AddHazardModal extends ConsumerStatefulWidget {
 
 class _AddHazardModalState extends ConsumerState<AddHazardModal> {
   final _picker = ImagePicker();
+  final String _uuid = kUuidGen.v1();
   HazardType? _selectedHazard;
   XFile? _image;
   bool _inProgress = false;
@@ -39,6 +40,7 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
 
   Future _submit() async {
     setState(() => _inProgress = true);
+
     final locationData = ref.read(locationProvider);
     if (!locationData.hasValue) {
       // TODO actually handle location errors
@@ -55,11 +57,15 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
         setState(() => _inProgress = false);
         return;
       }
-    } 
+    }
+
+    // Now close the modal so we don't submit more hazards
+    _close();
 
     final activeHazardNotifier = ref.read(activeHazardProvider.notifier);
 
     await activeHazardNotifier.createHazard(
+      uuid: _uuid,
       hazard: _selectedHazard!,
       location: snappedLoc.location,
       imageFile: _image
@@ -69,8 +75,6 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
       child: const Text("Your report has been queued"),
       color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
     );
-
-    _close();
   }
 
   Future _onSubmit() async {
@@ -239,7 +243,9 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
                         ),
                       ),
                       material: (context, _) => FilledButton(
-                        onPressed: _selectedHazard == null ? null : _onSubmit,
+                        onPressed: _selectedHazard == null || _inProgress
+                            ? null
+                            : _onSubmit,
                         child: const Text('Submit'),
                       ),
                     ),
@@ -268,13 +274,6 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
                   ),
                 ),
               ),
-              if (_inProgress)
-                const Align(
-                  alignment: Alignment.topCenter,
-                  child: LinearProgressIndicator(
-                    backgroundColor: Colors.transparent,
-                  ),
-                ),
             ],
           ),
         ),

--- a/lib/page/common/add_hazard_modal.dart
+++ b/lib/page/common/add_hazard_modal.dart
@@ -49,8 +49,10 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
     final location = locationData.requireValue;
     var snappedLoc = await ref.read(trailsProvider.notifier).snapLocation(location.latLng()!);
     
-    if (snappedLoc.distance > kLocationTolerance + (location.accuracy) && mounted) {
-      if (!await testLocationTooFar(context, ref, actionLocation: snappedLoc.location,
+    if (snappedLoc.distance > kAddLocationTolerance + (location.accuracy) && mounted) {
+      if (!await testLocationTooFar(context, ref,
+          tolerance: kAddLocationTolerance,
+          actionLocation: snappedLoc.location,
           title: "Too far from trail",
           content: "Reports must be made on a marked Forest Park trail",
           overrideEnabled: kLocationOverrideEnabled)) {

--- a/lib/page/common/add_hazard_modal.dart
+++ b/lib/page/common/add_hazard_modal.dart
@@ -72,8 +72,9 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
     );
 
     showAlertBanner(
+      key: Key(_uuid),
       child: const Text("Your report has been queued"),
-      color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
+      color: CupertinoDynamicColor.resolve(CupertinoColors.systemGrey, homeKey.currentContext!),
     );
   }
 

--- a/lib/page/common/add_hazard_modal.dart
+++ b/lib/page/common/add_hazard_modal.dart
@@ -70,12 +70,6 @@ class _AddHazardModalState extends ConsumerState<AddHazardModal> {
       location: snappedLoc.location,
       imageFile: _image
     );
-
-    showAlertBanner(
-      key: Key(_uuid),
-      child: const Text("Your report has been queued"),
-      color: CupertinoDynamicColor.resolve(CupertinoColors.systemGrey, homeKey.currentContext!),
-    );
   }
 
   Future _onSubmit() async {

--- a/lib/page/common/test_location_too_far.dart
+++ b/lib/page/common/test_location_too_far.dart
@@ -3,18 +3,18 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
-import 'package:forest_park_reports/consts.dart';
 import 'package:forest_park_reports/provider/location_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 
 Future<bool> testLocationTooFar(BuildContext context, WidgetRef ref, {
-  required LatLng actionLocation, 
-    String title = "Location is too far",
-    String? content,
-    String acceptText = "Ok",
-    bool overrideEnabled = false,
-    String overrideText = "Override",
+  required LatLng actionLocation,
+  required double tolerance,
+  String title = "Location is too far",
+  String? content,
+  String acceptText = "Ok",
+  bool overrideEnabled = false,
+  String overrideText = "Override",
 }) {
   
   final locationData = ref.read(locationProvider);
@@ -30,7 +30,7 @@ Future<bool> testLocationTooFar(BuildContext context, WidgetRef ref, {
   final location = locationData.requireValue; 
   if (context.mounted && 
       const DistanceVincenty().as(LengthUnit.Meter, LatLng(location.latitude, location.longitude), actionLocation)
-      <= kLocationTolerance + (location.accuracy)) {
+      <= tolerance + (location.accuracy)) {
     continueCompleter.complete(true);
     return continueCompleter.future;
   }

--- a/lib/page/home_page/panel_page.dart
+++ b/lib/page/home_page/panel_page.dart
@@ -50,6 +50,8 @@ class PanelPage extends ConsumerWidget {
       lastImage = hazardUpdates?.lastImage;
     }
 
+    final updateUuid = kUuidGen.v1();
+
     return Panel(
       // panel for when a hazard is selected
       child: selectedHazard != null ? TrailInfoWidget(
@@ -87,17 +89,13 @@ class PanelPage extends ConsumerWidget {
                     }
 
                     ref.read(activeHazardProvider.notifier).updateHazard(
+                      uuid: updateUuid,
                       hazard: selectedHazard.uuid,
                       active: false,
                     );
                     ref.read(panelPositionProvider.notifier).move(PanelState.HIDDEN);
                     ref.read(selectedHazardProvider.notifier).deselect();
                     ref.read(activeHazardProvider.notifier).refresh();
-
-                    showAlertBanner(
-                      child: const Text("Your report has been queued"),
-                      color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
-                    );
                   },
                   padding: EdgeInsets.zero,
                   child: const Text(
@@ -129,6 +127,7 @@ class PanelPage extends ConsumerWidget {
                     }
 
                     ref.read(activeHazardProvider.notifier).updateHazard(
+                      uuid: updateUuid,
                       hazard: selectedHazard.uuid,
                       active: true,
                     );
@@ -137,7 +136,7 @@ class PanelPage extends ConsumerWidget {
                     ref.read(activeHazardProvider.notifier).refresh();
 
                     showAlertBanner(
-                      child: const Text("Your report has been queued"),
+                      child: const Text("Your report has been queued", key: Key("Your report has been queued")),
                       color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
                     );
                   },

--- a/lib/page/home_page/panel_page.dart
+++ b/lib/page/home_page/panel_page.dart
@@ -81,6 +81,7 @@ class PanelPage extends ConsumerWidget {
                     }
                     
                     if (context.mounted && !await testLocationTooFar(context, ref,
+                      tolerance: kUpdateLocationTolerance,
                       actionLocation: LatLng(selectedHazard.location.latitude, selectedHazard.location.longitude),
                       title: "Too far from hazard",
                       content: "Hazard updates must be made in proximity to the hazard",
@@ -119,6 +120,7 @@ class PanelPage extends ConsumerWidget {
                     }
 
                     if (context.mounted && !await testLocationTooFar(context, ref,
+                      tolerance: kUpdateLocationTolerance,
                       actionLocation: LatLng(selectedHazard.location.latitude, selectedHazard.location.longitude),
                       title: "Too far from hazard",
                       content: "Hazard updates must be made in proximity to the hazard",

--- a/lib/provider/hazard_provider.dart
+++ b/lib/provider/hazard_provider.dart
@@ -69,6 +69,7 @@ class ActiveHazard extends _$ActiveHazard {
   }
 
   Future<void> createHazard({
+    required String uuid,
     required HazardType hazard,
     required SnappedLatLng location,
     XFile? imageFile
@@ -82,6 +83,7 @@ class ActiveHazard extends _$ActiveHazard {
     }
 
     final hazardRequest = HazardModel.create(
+      uuid: uuid,
       hazard: hazard,
       location: location,
       image: image != null ? kUuidGen.v1() : null,

--- a/lib/provider/hazard_provider.dart
+++ b/lib/provider/hazard_provider.dart
@@ -1,10 +1,15 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:forest_park_reports/consts.dart';
+import 'package:forest_park_reports/main.dart';
 import 'package:forest_park_reports/model/hazard_new_response.dart';
 import 'package:forest_park_reports/model/hazard_type.dart';
 import 'package:forest_park_reports/model/queued_request.dart';
 import 'package:forest_park_reports/model/snapped_latlng.dart';
+import 'package:forest_park_reports/page/common/alert_banner.dart';
 import 'package:forest_park_reports/provider/directory_provider.dart';
 import 'package:forest_park_reports/util/image_extensions.dart';
 import 'package:forest_park_reports/util/offline_uploader.dart';
@@ -123,7 +128,12 @@ class ActiveHazard extends _$ActiveHazard {
   }
 
   Future<void> handleCreateResponse(HazardNewResponseModel response) async {
-    print("Handling hazard create response: $response");
+    // Show success notification
+    showAlertBanner(
+      key: Key(response.hazard.uuid),
+      child: const Text("Report uploaded successfully"),
+      color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
+    );
 
     _addHazard(response.hazard);
 

--- a/lib/provider/hazard_provider.dart
+++ b/lib/provider/hazard_provider.dart
@@ -79,6 +79,13 @@ class ActiveHazard extends _$ActiveHazard {
     required SnappedLatLng location,
     XFile? imageFile
   }) async {
+    // Show alert that upload queued
+    showAlertBanner(
+      key: Key(uuid),
+      child: const Text("Your report has been queued", key: Key("Your report has been queued")),
+      color: CupertinoDynamicColor.resolve(CupertinoColors.systemGrey, homeKey.currentContext!),
+    );
+
     // If we're passed an image, decode it.
     img.Image? image;
     if (imageFile != null) {
@@ -131,7 +138,7 @@ class ActiveHazard extends _$ActiveHazard {
     // Show success notification
     showAlertBanner(
       key: Key(response.hazard.uuid),
-      child: const Text("Report uploaded successfully"),
+      child: const Text("Report uploaded successfully", key: Key("Report uploaded successfully")),
       color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
     );
 
@@ -156,10 +163,18 @@ class ActiveHazard extends _$ActiveHazard {
   }
 
   Future updateHazard({
+    required String uuid,
     required String hazard,
     required bool active,
     XFile? imageFile
   }) async {
+    // Show alert that update queued
+    showAlertBanner(
+      key: Key(uuid),
+      child: const Text("Your report has been queued", key: Key("Your report has been queued")),
+      color: CupertinoDynamicColor.resolve(CupertinoColors.systemGrey, homeKey.currentContext!),
+    );
+
     // If we're passed an image, decode it.
     img.Image? image;
     if (imageFile != null) {
@@ -169,6 +184,7 @@ class ActiveHazard extends _$ActiveHazard {
     }
 
     final hazardUpdateRequest = HazardUpdateModel.create(
+      uuid: uuid,
       hazard: hazard,
       active: active,
       image: image != null ? kUuidGen.v1() : null,
@@ -205,7 +221,12 @@ class ActiveHazard extends _$ActiveHazard {
   }
 
   Future<void> handleUpdateResponse(HazardUpdateModel hazardUpdate) async {
-    print("Handling hazard update create response: $hazardUpdate");
+    // Show success notification
+    showAlertBanner(
+      key: Key(hazardUpdate.uuid),
+      child: const Text("Report uploaded successfully", key: Key("Report uploaded successfully")),
+      color: CupertinoDynamicColor.resolve(CupertinoColors.activeGreen, homeKey.currentContext!),
+    );
 
     // Add new update to hazard updates
     await ref.read(hazardUpdatesProvider(hazardUpdate.hazard).notifier)


### PR DESCRIPTION
Adds a key to `showAlertBanner` which allows updating existing alert banners. Adds transitions when child key is changed.
Reworks the add hazard flow to immediately close the panel on submit, show a queued notification, then update that notification when the submission is successful.
Fixes submit button not disabling after press on Android.
Separates the location tolerances of add and update hazard

Closes #55
Closes #58 
Closes #56